### PR TITLE
Fix connection reference on NewDriver

### DIFF
--- a/bin/main.go
+++ b/bin/main.go
@@ -6,5 +6,5 @@ import (
 )
 
 func main() {
-	plugin.RegisterDriver(kvm.NewDriver())
+	plugin.RegisterDriver(kvm.NewDriver("default", "path"))
 }

--- a/kvm.go
+++ b/kvm.go
@@ -162,7 +162,7 @@ func (d *Driver) DriverName() string {
 }
 
 func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
-	log.Debugf("SetConfigFromFlags aclled")
+	log.Debugf("SetConfigFromFlags called")
 	d.Memory = flags.Int("kvm-memory")
 	d.DiskSize = flags.Int("kvm-disk-size")
 	d.CPU = flags.Int("kvm-cpu-count")
@@ -274,7 +274,6 @@ func (d *Driver) validateNetwork(name string) error {
 func (d *Driver) PreCreateCheck() error {
 	// TODO We could look at d.conn.GetCapabilities()
 	// parse the XML, and look for kvm
-
 	log.Debug("About to check libvirt version")
 
 	// TODO might want to check minimum version
@@ -670,13 +669,19 @@ func createDiskImage(dest string, size int, r io.Reader) error {
 	return f.Close()
 }
 
-func NewDriver() *Driver {
-	d := &Driver{}
-	conn, err := libvirt.NewVirConnection(d.connectionString)
+func NewDriver(hostName, storePath string) drivers.Driver {
+	conn, err := libvirt.NewVirConnection(connectionString)
 	if err != nil {
 		log.Fatalf("Failed to connect to libvirt: %s", err)
+		return nil
 	}
-	d.conn = &conn
-	d.PrivateNetwork = privateNetworkName
-	return d
+
+	return &Driver{
+		conn:           &conn,
+		PrivateNetwork: privateNetworkName,
+		BaseDriver: &drivers.BaseDriver{
+			MachineName: hostName,
+			StorePath:   storePath,
+		},
+	}
 }


### PR DESCRIPTION
This fix the driver initialization caused by `d.connectionString` not being initialized when the Driver is created, this will make subsequent calls use qemu:///session instead of qemu:///system and network.Create will fail with this message.

```
(local-kvm) DBG | Reactivating private network: %!s(<nil>)
Error creating machine: Error with pre-create check: [Code-38] [Domain-0] error creating bridge interface virbr0: Operation not permitted
```

Also changed the function signature to match with what is used in other driver, not related to the issue though.