### PR TITLE
Return KVM Driver for easier customization

### DIFF
--- a/kvm.go
+++ b/kvm.go
@@ -669,7 +669,7 @@ func createDiskImage(dest string, size int, r io.Reader) error {
 	return f.Close()
 }
 
-func NewDriver(hostName, storePath string) drivers.Driver {
+func NewDriver(hostName, storePath string) *Driver {
 	conn, err := libvirt.NewVirConnection(connectionString)
 	if err != nil {
 		log.Errorf("Failed to connect to libvirt: %s", err)


### PR DESCRIPTION
When embedding in other projects, need access to the KVM Driver struct rather the interface.

Also see https://twitter.com/davecheney/status/747953959529119744 :)