### PR TITLE
Use the libvirt API to obtain DHCP leases.

### DIFF
--- a/cmd/docker-machine-driver-kvm/Makefile
+++ b/cmd/docker-machine-driver-kvm/Makefile
@@ -1,4 +1,4 @@
 default: build
 
 build:
-	GOGC=off go build -i -o docker-machine-driver-kvm
+	GOGC=off go build -tags libvirt.1.2.14 -i -o docker-machine-driver-kvm


### PR DESCRIPTION
Requires libvirt >= 1.2.6 and recent version of libvirt-go. The tag `libvirt.1.2.14` is required by libvirt-go to enable its use, since a wider range of libvirt versions are supported there.

Why use the libvirt API? Well, besides a simpler implementation, and less dependent on libvirtd's files, etc... I'm interested in it primarily because I'd like to run this plugin in an apparmor-restricted environment that only allows access to the libvirtd socket. Pretty harsh, but that's what I've got to work with.

So I wasn't sure of the minimum version of libvirt you want to support with this plugin. If you want the other IP lookup methods back, I'm happy to add them back in as fallbacks, or used when the libvirt.1.2.14 build tag isn't set. However, I thought I'd be a little bold and see if you really needed them. Anyway, let me know!
