### PR TITLE
The current domain XML used for the KVM driver does not specify a CPU mode...

### DIFF
--- a/kvm.go
+++ b/kvm.go
@@ -35,6 +35,7 @@ const (
   <name>{{.MachineName}}</name> <memory unit='M'>{{.Memory}}</memory>
   <vcpu>{{.CPU}}</vcpu>
   <features><acpi/><apic/><pae/></features>
+  <cpu mode='host-passthrough'></cpu>
   <os>
     <type>hvm</type>
     <boot dev='cdrom'/>


### PR DESCRIPTION
…which makes things very slow and usually lead to a constant >25% CPU usage for people using your driver with Kubernetes and Minikube. This solves the problem as it simply tells KVM to use everything the host supports and emulate whatever else is needed.

See http://wiki.qemu.org/Features/CPUModels#-cpu_host_and_feature_probing for more info. CPU host mode is usually safe and recommended for scenarios like the ones this driver is used for. The only limitation (which I suspect is not a big deal here) is that if KVM migrations between hosts of different CPUs models are too frequent.