### PR TITLE
Use last entry when parsing DHCP status file

### DIFF
--- a/kvm.go
+++ b/kvm.go
@@ -636,13 +636,18 @@ func (d *Driver) getIPByMacFromSettings(mac string) (string, error) {
 		log.Warnf("Failed to decode dnsmasq lease status: %s", err)
 		return "", err
 	}
+	ipAddr := ""
 	for _, value := range s {
 		if strings.ToLower(value.Mac_address) == strings.ToLower(mac) {
-			log.Debugf("IP address: %s", value.Ip_address)
-			return value.Ip_address, nil
+			// If there are multiple entries,
+			// the last one is the most current
+			ipAddr = value.Ip_address
 		}
 	}
-	return "", nil
+	if ipAddr != "" {
+		log.Debugf("IP address: %s", ipAddr)
+	}
+	return ipAddr, nil
 }
 
 func (d *Driver) GetIP() (string, error) {


### PR DESCRIPTION
When a machine is stopped and restarted, it may get allocated a new IP.
 The loop that parsing the status file returns on the first match,
which is the entry for the old IP so that machine fails to start up.