### PR TITLE
Use the libvirt API to obtain domain IP address

### DIFF
--- a/cmd/docker-machine-driver-kvm/Makefile
+++ b/cmd/docker-machine-driver-kvm/Makefile
@@ -1,4 +1,4 @@
 default: build
 
 build:
-	GOGC=off go build -i -o docker-machine-driver-kvm
+	GOGC=off go build -tags libvirt.1.2.14 -i -o docker-machine-driver-kvm

--- a/kvm.go
+++ b/kvm.go
@@ -592,6 +592,25 @@ func (d *Driver) getMAC() (string, error) {
 	return dom.Devices.Interfaces[1].Mac.Address, nil
 }
 
+func (d *Driver) getIPByMACFromAPI(mac string) (string, error) {
+	network, err := d.conn.LookupNetworkByName(d.PrivateNetwork)
+	if err != nil {
+		log.Errorf("Failed to lookup network %s", d.PrivateNetwork)
+		return "", err
+	}
+	leases, err := network.GetDHCPLeases()
+	if err != nil {
+		log.Warnf("Failed to retrieve DHCP leases from libvirt: %v", err)
+		return "", err
+	}
+	for _, lease := range leases {
+		if strings.ToLower(mac) == strings.ToLower(lease.GetMACAddress()) {
+			return lease.GetIPAddress(), nil
+		}
+	}
+	return "", errors.New("failed to match IP for MAC address")
+}
+
 func (d *Driver) getIPByMACFromLeaseFile(mac string) (string, error) {
 	leaseFile := fmt.Sprintf(dnsmasqLeases, d.PrivateNetwork)
 	data, err := ioutil.ReadFile(leaseFile)
@@ -633,6 +652,11 @@ func (d *Driver) getIPByMacFromSettings(mac string) (string, error) {
 	}
 	statusFile := fmt.Sprintf(dnsmasqStatus, bridge_name)
 	data, err := ioutil.ReadFile(statusFile)
+	if err != nil {
+		log.Debugf("Failed to read dnsmasq status from %s", statusFile)
+		return "", err
+	}
+
 	type Lease struct {
 		Ip_address  string `json:"ip-address"`
 		Mac_address string `json:"mac-address"`
@@ -659,22 +683,27 @@ func (d *Driver) getIPByMacFromSettings(mac string) (string, error) {
 	return ipAddr, nil
 }
 
+type ipLookupFunc func(mac string) (string, error)
+
 func (d *Driver) GetIP() (string, error) {
 	log.Debugf("GetIP called for %s", d.MachineName)
 	mac, err := d.getMAC()
 	if err != nil {
 		return "", err
 	}
-	/*
-	 * TODO - Figure out what version of libvirt changed behavior and
-	 *        be smarter about selecting which algorithm to use
-	 */
-	ip, err := d.getIPByMACFromLeaseFile(mac)
-	if ip == "" {
-		ip, err = d.getIPByMacFromSettings(mac)
+
+	methods := []ipLookupFunc{
+		d.getIPByMACFromLeaseFile,
+		d.getIPByMacFromSettings,
+		d.getIPByMACFromAPI,
 	}
-	log.Debugf("Unable to locate IP address for MAC %s", mac)
-	return ip, err
+	for _, method := range methods {
+		ip, err := method(mac)
+		if err == nil {
+			return ip, nil
+		}
+	}
+	return "", fmt.Errorf("unable to locate IP address for MAC %s")
 }
 
 func (d *Driver) publicSSHKeyPath() string {


### PR DESCRIPTION
This is a complete revamp of https://github.com/dhiltgen/docker-machine-kvm/pull/2.

The code has been changed to use the right API provided by the official libvirt-go bindings. The previous PR was using a different Go binding library.