### PR TITLE
Modify Makefile and Dockerfiles to speed up builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.dockerignore
+out
+dockerfiles
+make

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cmd/docker-machine-driver-kvm/docker-machine-driver-kvm
 *.sw*
 docker-machine-driver-kvm-*
+out

--- a/dockerfiles/Dockerfile.alpine3.4
+++ b/dockerfiles/Dockerfile.alpine3.4
@@ -1,15 +1,11 @@
-FROM alpine:3.5
+FROM alpine:3.4
 
 MAINTAINER Daniel Hiltgen <daniel.hiltgen@docker.com>
 
 ARG MACHINE_VERSION
+# Uncomment the following line to build with docker engine < 1.13
+# ARG GO_VERSION
 ENV GOPATH /go
 
 RUN apk -v add --update libvirt-dev curl go git musl-dev gcc
 RUN git clone --branch ${MACHINE_VERSION} https://github.com/docker/machine.git /go/src/github.com/docker/machine
-
-COPY . /go/src/github.com/dhiltgen/docker-machine-kvm
-WORKDIR /go/src/github.com/dhiltgen/docker-machine-kvm
-RUN go get -v -d ./...
-
-RUN go install -v ./cmd/docker-machine-driver-kvm

--- a/dockerfiles/Dockerfile.alpine3.5
+++ b/dockerfiles/Dockerfile.alpine3.5
@@ -1,15 +1,11 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 MAINTAINER Daniel Hiltgen <daniel.hiltgen@docker.com>
 
 ARG MACHINE_VERSION
+# Uncomment the following line to build with docker engine < 1.13
+# ARG GO_VERSION
 ENV GOPATH /go
 
 RUN apk -v add --update libvirt-dev curl go git musl-dev gcc
 RUN git clone --branch ${MACHINE_VERSION} https://github.com/docker/machine.git /go/src/github.com/docker/machine
-
-COPY . /go/src/github.com/dhiltgen/docker-machine-kvm
-WORKDIR /go/src/github.com/dhiltgen/docker-machine-kvm
-RUN go get -v -d ./...
-
-RUN go install -v ./cmd/docker-machine-driver-kvm

--- a/dockerfiles/Dockerfile.centos7
+++ b/dockerfiles/Dockerfile.centos7
@@ -8,11 +8,4 @@ ENV GOPATH /go
 
 RUN yum install -y libvirt-devel curl git gcc
 RUN curl -sSL https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /usr/local -xzf -
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/go/bin
 RUN git clone --branch ${MACHINE_VERSION} https://github.com/docker/machine.git /go/src/github.com/docker/machine
-
-COPY . /go/src/github.com/dhiltgen/docker-machine-kvm
-WORKDIR /go/src/github.com/dhiltgen/docker-machine-kvm
-RUN go get -v -d ./...
-
-RUN go install -v ./cmd/docker-machine-driver-kvm

--- a/dockerfiles/Dockerfile.opensuse42.2
+++ b/dockerfiles/Dockerfile.opensuse42.2
@@ -1,0 +1,12 @@
+FROM opensuse:42.2
+
+LABEL maintainer "Hart Simha <hart.simha@suse.com>"
+RUN zypper -n in libvirt-devel curl git gcc tar && \
+    git clone https://github.com/docker/machine.git /go/src/github.com/docker/machine
+
+ARG GO_VERSION
+RUN curl -sSL https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+
+ARG MACHINE_VERSION
+WORKDIR /go/src/github.com/docker/machine
+RUN git checkout $MACHINE_VERSION

--- a/dockerfiles/Dockerfile.ubuntu14.04
+++ b/dockerfiles/Dockerfile.ubuntu14.04
@@ -8,11 +8,4 @@ ENV GOPATH /go
 
 RUN apt-get update && apt-get install -y libvirt-dev curl git gcc
 RUN curl -sSL https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /usr/local -xzf -
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/go/bin
 RUN git clone --branch ${MACHINE_VERSION} https://github.com/docker/machine.git /go/src/github.com/docker/machine
-
-COPY . /go/src/github.com/dhiltgen/docker-machine-kvm
-WORKDIR /go/src/github.com/dhiltgen/docker-machine-kvm
-RUN go get -v -d ./...
-
-RUN go install -v ./cmd/docker-machine-driver-kvm

--- a/dockerfiles/Dockerfile.ubuntu16.04
+++ b/dockerfiles/Dockerfile.ubuntu16.04
@@ -8,11 +8,4 @@ ENV GOPATH /go
 
 RUN apt-get update && apt-get install -y libvirt-dev curl git gcc
 RUN curl -sSL https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /usr/local -xzf -
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/go/bin
 RUN git clone --branch ${MACHINE_VERSION} https://github.com/docker/machine.git /go/src/github.com/docker/machine
-
-COPY . /go/src/github.com/dhiltgen/docker-machine-kvm
-WORKDIR /go/src/github.com/dhiltgen/docker-machine-kvm
-RUN go get -v -d ./...
-
-RUN go install -v ./cmd/docker-machine-driver-kvm

--- a/make/base
+++ b/make/base
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+
+# This script creates the platform-specific base image used as the FROM base for constructing 
+# the image which will be used to generate the docker-machine-driver-kvm-$platform binary.
+# It expects the base image name (taking the form of $PREFIX-base:$PLATFORM) to be passed as an argument
+set -e
+GO_VERSION_ARG=GO_VERSION=${GO_VERSION:-1.8.1}
+MACHINE_VERSION_ARG=MACHINE_VERSION=${MACHINE_VERSION:-v0.10.0}
+GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
+
+# Extract values 'BASE_IMAGE_NAME:PLATFORM' from the image name argument
+BASE_IMAGE_NAME=${1%:*}
+PLATFORM=${1#*:}
+
+# If the base image for this platform, go version, and machine version is not already present, build it.
+# Labels are used to track the GO_VERSION and MACHINE_VERSION
+if [ -z "$(docker images -q $@ -f label=$GO_VERSION_ARG -f label=$MACHINE_VERSION_ARG)" ]; then
+  # If an image with this BASE_IMAGE_NAME:PLATFORM already exists, store its ID for deletion later
+  PREVIOUS_IMAGE=$(docker images -q $@)
+  # Build the new image before deleting any previous one, to reuse common layers
+  docker build \
+    --label $GO_VERSION_ARG      --build-arg $GO_VERSION_ARG \
+    --label $MACHINE_VERSION_ARG --build-arg $MACHINE_VERSION_ARG \
+    -t $@ \
+    -f "${GIT_ROOT}/dockerfiles/Dockerfile.${PLATFORM}" \
+    "${GIT_ROOT}"
+  if [ -n "$PREVIOUS_IMAGE" ]; then
+    docker rmi $PREVIOUS_IMAGE
+  fi
+else
+  echo "Image '$@' with labels $GO_VERSION_ARG $MACHINE_VERSION_ARG already exists"
+fi

--- a/make/build
+++ b/make/build
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+
+# This script builds the docker-machine-driver-kvm binary by first building a temporary
+# image with the relevant docker-machine-kvm code inside, and PATH and GO_PATH set. The binary
+# is then built in a container from this image and into 'out/'. Finally, the temporary
+# image and container (with suffixes '-build' and '-extract) are deleted
+
+set -e
+PREFIX=${PREFIX:-docker-machine-driver-kvm}
+GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
+
+BASE_IMAGE=$@
+PLATFORM=${BASE_IMAGE#*:}
+BUILD_TARGET=$PREFIX-$PLATFORM
+BUILD_IMAGE=$PREFIX-build:$PLATFORM
+
+echo "Building compilation image for out/$PREFIX-$PLATFORM"
+docker build -t $BUILD_IMAGE -f "${GIT_ROOT}/Dockerfile.$PLATFORM.build" "${GIT_ROOT}"
+
+echo "Building binaries for out/$PREFIX-$PLATFORM"
+docker run --name $BUILD_TARGET-extract $BUILD_IMAGE sh -c "cd /go/src/github.com/dhiltgen/docker-machine-kvm && go get -v -d ./... && go install -v ./cmd/docker-machine-driver-kvm"
+docker cp $BUILD_TARGET-extract:/go/bin/docker-machine-driver-kvm out/$BUILD_TARGET
+docker rm $BUILD_TARGET-extract
+docker rmi $BUILD_IMAGE


### PR DESCRIPTION
This PR speeds up the build process by keeping a base image for each targeted platform, and moving the COPY step from the Dockerfiles into a separate Dockerfile which gets built from the base image. The base images will only be rebuilt when the user has deleted them, or when the GO_VERSION or MACHINE_VERSION has changed since they were built.  In case of GO_VERSION or MACHINE_VERSION changing, the cache will be reused from the previous build (which is most useful for the steps where the libvirt package installed, which requires update/refreshing package repositories in addition to downloading the packages). The image which gets the repo root copied in, and associated container which actually performs the `go get ... && go install ...` are still deleted after each build.

This PR also:
* Moves the Dockerfiles which create the base images into a 'dockerfiles/' directory
* Changes the destination path of the compiled binaries to './out/'
* Adds a .dockerignore which will prevent the binaries from being copied into the build image on successive builds
