### PR TITLE
Set group executable bit on machine-specific directory and up

### DIFF
--- a/kvm.go
+++ b/kvm.go
@@ -370,7 +370,7 @@ func (d *Driver) Create() error {
 		mode := info.Mode()
 		if mode&0001 != 1 {
 			log.Debugf("Setting executable bit set on %s", dir)
-			mode |= 0001
+			mode |= 0011
 			os.Chmod(dir, mode)
 		}
 	}

--- a/kvm.go
+++ b/kvm.go
@@ -368,7 +368,7 @@ func (d *Driver) Create() error {
 			return err
 		}
 		mode := info.Mode()
-		if mode&0001 != 1 {
+		if mode&0011 != 1 {
 			log.Debugf("Setting executable bit set on %s", dir)
 			mode |= 0011
 			os.Chmod(dir, mode)


### PR DESCRIPTION
Set group-executable bit on machine-specific directory and up

Ensure that the directories leading to the KVM image have enough
permission for libvirt/QEMU to traverse, especially in the case where
libvirt/QEMU group is set to to `kvm`/`users`.

Fixes #46.