### PR TITLE
Add GitLab CI runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,14 @@
+build:
+  image: fedora:26
+  variables:
+    DOCKER_HOST: "tcp://gbraad__dind-options:2375"
+  services:
+    - gbraad/dind-options:latest
+  script:
+    - dnf install -y docker make git
+    - make
+    - mkdir -p public
+    - mv docker-machine-driver-kvm-* ./public
+  artifacts:
+    paths:
+      - public


### PR DESCRIPTION
Use this myself to build the multiple targets. Also works on the shared CI runner:
  * https://gitlab.com/gbraad/docker-machine-kvm/-/jobs/29416725