### PR TITLE
Added Debian9 support

### DIFF
--- a/Dockerfile.debian9
+++ b/Dockerfile.debian9
@@ -4,6 +4,7 @@ MAINTAINER Daniel Hiltgen <daniel.hiltgen@docker.com>
 
 ARG MACHINE_VERSION
 ARG GO_VERSION
+ARG PLUGIN_VERSION
 ENV GOPATH /go
 
 RUN apt-get update && apt-get install -y libvirt-dev curl git gcc
@@ -15,4 +16,4 @@ COPY . /go/src/github.com/dhiltgen/docker-machine-kvm
 WORKDIR /go/src/github.com/dhiltgen/docker-machine-kvm
 RUN go get -v -d ./...
 
-RUN go install -v ./cmd/docker-machine-driver-kvm
+RUN go install -v -ldflags="-X main.goVersion=${GO_VERSION} -X main.machineVersion=${MACHINE_VERSION} -X main.pluginVersion=${PLUGIN_VERSION}" ./cmd/docker-machine-driver-kvm

--- a/Dockerfile.debian9
+++ b/Dockerfile.debian9
@@ -1,0 +1,18 @@
+FROM debian:9
+
+MAINTAINER Daniel Hiltgen <daniel.hiltgen@docker.com>
+
+ARG MACHINE_VERSION
+ARG GO_VERSION
+ENV GOPATH /go
+
+RUN apt-get update && apt-get install -y libvirt-dev curl git gcc
+RUN curl -sSL https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/go/bin
+RUN git clone --branch ${MACHINE_VERSION} https://github.com/docker/machine.git /go/src/github.com/docker/machine
+
+COPY . /go/src/github.com/dhiltgen/docker-machine-kvm
+WORKDIR /go/src/github.com/dhiltgen/docker-machine-kvm
+RUN go get -v -d ./...
+
+RUN go install -v ./cmd/docker-machine-driver-kvm

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ $(PREFIX)-%: Dockerfile.%
 	docker rmi -f $@ >/dev/null  2>&1 || true
 	docker rm -f $@-extract > /dev/null 2>&1 || true
 	echo "Building binaries for $@"
-	docker build --build-arg "MACHINE_VERSION=$(MACHINE_VERSION)" --build-arg "GO_VERSION=$(GO_VERSION)" -t $@ -f $< .
+	docker build --build-arg "MACHINE_VERSION=$(MACHINE_VERSION)" --build-arg "GO_VERSION=$(GO_VERSION)" --build-arg "PLUGIN_VERSION=$(DESCRIBE)" -t $@ -f $< .
 	docker create --name $@-extract $@ sh
 	docker cp $@-extract:/go/bin/docker-machine-driver-kvm ./
 	mv ./docker-machine-driver-kvm ./$@

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MACHINE_VERSION=v0.10.0
 GO_VERSION=1.8.1
 DESCRIBE=$(shell git describe --tags)
 
-TARGETS=$(addprefix $(PREFIX)-, alpine3.4 alpine3.5 ubuntu14.04 ubuntu16.04 centos7)
+TARGETS=$(addprefix $(PREFIX)-, alpine3.4 alpine3.5 ubuntu14.04 ubuntu16.04 centos7 debian9)
 
 build: $(TARGETS)
 

--- a/cmd/docker-machine-driver-kvm/main.go
+++ b/cmd/docker-machine-driver-kvm/main.go
@@ -3,8 +3,21 @@ package main
 import (
 	"github.com/dhiltgen/docker-machine-kvm"
 	"github.com/docker/machine/libmachine/drivers/plugin"
+	"flag"
+	"fmt"
 )
 
+// Will be set using "-X" linker option during build
+var goVersion = "undefined"
+var machineVersion = "undefined"
+var pluginVersion = "undefined"
+
 func main() {
-	plugin.RegisterDriver(kvm.NewDriver("default", "path"))
+	versionPtr := flag.Bool("version", true, "print version number")
+	flag.Parse()
+	if  *versionPtr {
+		fmt.Printf("go: %s\nmachine: %s\nplugin: %s\n", goVersion, machineVersion, pluginVersion)
+	} else {
+		plugin.RegisterDriver(kvm.NewDriver("default", "path"))
+	}
 }


### PR DESCRIPTION
I originally cloned this to see if I could add some way to print a version number, but started with (trivially) adding Debian:9 support