### PR TITLE
Allow to pass a different url for contacting libvirt

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,5 @@ Here are all currently driver parameters listed that you can use.
 | **--kvm-boot2docker-url** | Sets the url from which host the image is loaded. By default it's not set.   |
 | **--kvm-cache-mode** | Sets the caching mode of the kvm machine. Defaults to `default`.   |    
 | **--kvm-io-mode-url** | Sets the disk io mode of the kvm machine. Defaults to `threads`.   |      
-
-
-
+| **--kvm-connection-url** | Sets the url to access libvirtd. Defaults to `qemu:///system`.   |      
+| **--kvm-pool** | Sets the pool to use. Defaults to `default`.   |      


### PR DESCRIPTION
this adds new parameters:
 - kvm-connection-url (which defaults to qemu:///system)
- kvm-pool (which defaults to default)

the corresponding attribute (d.ConnectionString), capitalized for that matter  is now exposed in the config of the vm (to allow post creation operations on the vm).
uploading of the bootdocker iso and custom image file is done using the libvirt api 
additionally , we use an alternative to retrieve the ip of the vm by checking leases server side and also make sure the uploaded image gets properly deleted upon removal of the vm
