### PR TITLE
support alternatives to default (rtl8139) NIC type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ PREFIX=docker-machine-driver-kvm
 MACHINE_VERSION=v0.10.0
 GO_VERSION=1.8.1
 DESCRIBE=$(shell git describe --tags)
+ORIGIN=$(shell git remote -v | grep '(push)$$' | sed -e 's!\S\S*\s\s*\(\S\S*\)\s.*!\1!')
+REPOSITORY=$(shell echo '$(ORIGIN)' | sed -e 's!\(https://\|\S\S*@\)\([^/:][^/:]*\)[/:]\(.*\)\.git$$!https://\2/\3!')
 
 TARGETS=$(addprefix $(PREFIX)-, alpine3.4 alpine3.5 ubuntu14.04 ubuntu16.04 centos7)
 
@@ -27,11 +29,15 @@ release: build
 	@echo ""
 	@for bin in $(PREFIX)-* ; do \
 	    target=$$(echo $${bin} | cut -f5- -d-) ; \
-	    md5=$$(md5sum $${bin}) ; \
-	    echo "* $${target} - md5: $${md5}" ; \
+	    md5=$$(md5sum $${bin} | cut -f1 -d' ') ; \
+	    sha256=$$(sha256sum $${bin} | cut -f1 -d' ') ; \
+	    echo "#### $${target}" ; \
+	    echo "$${bin}" ; \
+	    echo "* SHA-256: $${sha256}" ; \
+	    echo "* MD5: $${md5}" ; \
 	    echo '```' ; \
-	    echo "  curl -L https://github.com/dhiltgen/docker-machine-kvm/releases/download/$(DESCRIBE)/$${bin} > /usr/local/bin/$(PREFIX) \\ " ; \
-	    echo "  chmod +x /usr/local/bin/$(PREFIX)" ; \
+	    echo "curl -L $(REPOSITORY)/releases/download/$(DESCRIBE)/$${bin} > /usr/local/bin/$(PREFIX) && \\"; \
+	    echo "chmod +x /usr/local/bin/$(PREFIX)" ; \
 	    echo '```' ; \
 	done
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Here are all currently driver parameters listed that you can use.
 | **--kvm-boot2docker-url** | Sets the url from which host the image is loaded. By default it's not set.   |
 | **--kvm-cache-mode** | Sets the caching mode of the kvm machine. Defaults to `default`.   |    
 | **--kvm-io-mode-url** | Sets the disk io mode of the kvm machine. Defaults to `threads`.   |      
+| **--kvm-nic-type** | Sets the model of the network interfaces of the kvm machine. Defaults to `default`. |
 
 
 

--- a/kvm.go
+++ b/kvm.go
@@ -59,9 +59,11 @@ const (
       <listen type='address' address='127.0.0.1'/>
     </graphics>
     <interface type='network'>
+      {{.NICModelElement}}
       <source network='{{.Network}}'/>
     </interface>
     <interface type='network'>
+      {{.NICModelElement}}
       <source network='{{.PrivateNetwork}}'/>
     </interface>
   </devices>
@@ -91,6 +93,7 @@ type Driver struct {
 	DiskPath         string
 	CacheMode        string
 	IOMode           string
+	NICModelElement  string
 	connectionString string
 	conn             *libvirt.Connect
 	VM               *libvirt.Domain
@@ -135,6 +138,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:  "kvm-io-mode",
 			Usage: "Disk IO mode: threads, native",
 			Value: "threads",
+		},
+		mcnflag.StringFlag{
+			Name:  "kvm-nic-type",
+			Usage: "Network interface model type: default, e1000, rtl8139, virtio, etc.",
+			Value: "default",
 		},
 		mcnflag.StringFlag{
 			EnvVar: "KVM_SSH_USER",
@@ -200,6 +208,12 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SSHUser = flags.String("kvm-ssh-user")
 	d.SSHPort = 22
 	d.DiskPath = d.ResolveStorePath(fmt.Sprintf("%s.img", d.MachineName))
+
+	if flags.String("kvm-nic-type") == "default" {
+		d.NICModelElement = ""
+	} else {
+		d.NICModelElement = fmt.Sprintf("<model type='%s'/>", flags.String("kvm-nic-type"))
+	}
 	return nil
 }
 


### PR DESCRIPTION
Introduces new flag: --kvm-nic-type <nic-type>

Example command line: 
```
docker-machine create -d kvm --kvm-network "docker-machines" --kvm-nic-type virtio local
```
