### PR TITLE
Add option to add extra file. Allows using a registry mirror with dind.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Here are all currently driver parameters listed that you can use.
 | **--kvm-boot2docker-url** | Sets the url from which host the image is loaded. By default it's not set.   |
 | **--kvm-cache-mode** | Sets the caching mode of the kvm machine. Defaults to `default`.   |    
 | **--kvm-io-mode-url** | Sets the disk io mode of the kvm machine. Defaults to `threads`.   |      
+| **--kvm-extra-file** | Adds the specified file to /home/docker (optional). |
 
 
 


### PR DESCRIPTION
This is needed for using a registry mirror in a docker-in-docker container: https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#the-docker-executor-in-the-gitlab-runner-configuration-file